### PR TITLE
Add dark mode and UI toggle

### DIFF
--- a/README-WEB.md
+++ b/README-WEB.md
@@ -10,6 +10,7 @@ Una aplicación web moderna y responsive para gestionar tareas personales con un
 - **Interfaz intuitiva** con iconos y colores atractivos
 - **Animaciones suaves** para una mejor experiencia de usuario
 - **Tema moderno** con gradientes y sombras elegantes
+- **Modo oscuro** opcional con botón de activación
 
 ### 📊 Panel de Estadísticas en Tiempo Real
 

--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ class GestorTareasWeb {
         
         // Cargar tareas guardadas al iniciar
         this.cargarTareas();
+
+        // Cargar tema guardado
+        this.cargarTema();
         
         // Inicializar la aplicación
         this.inicializar();
@@ -61,6 +64,11 @@ class GestorTareasWeb {
         // Botón de estadísticas
         document.getElementById('btn-estadisticas').addEventListener('click', () => {
             this.mostrarEstadisticasDetalladas();
+        });
+
+        // Botón de modo oscuro
+        document.getElementById('toggle-dark-mode').addEventListener('click', () => {
+            this.toggleDarkMode();
         });
 
         // Modales
@@ -424,11 +432,38 @@ class GestorTareasWeb {
     mostrarConfirmacion(mensaje, callback) {
         document.getElementById('mensaje-confirmacion').textContent = mensaje;
         document.getElementById('modal-confirmacion').style.display = 'block';
-        
+
         document.getElementById('btn-confirmar').onclick = () => {
             document.getElementById('modal-confirmacion').style.display = 'none';
             callback();
         };
+    }
+
+    /**
+     * Alterna entre modo claro y oscuro
+     */
+    toggleDarkMode() {
+        const body = document.body;
+        const temaActual = body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        const nuevoTema = temaActual === 'dark' ? 'light' : 'dark';
+        body.setAttribute('data-theme', nuevoTema);
+        localStorage.setItem('tema', nuevoTema);
+        const btn = document.getElementById('toggle-dark-mode');
+        if (btn) {
+            btn.textContent = nuevoTema === 'dark' ? '☀ Modo Claro' : '🌙 Modo Oscuro';
+        }
+    }
+
+    /**
+     * Carga el tema guardado desde localStorage
+     */
+    cargarTema() {
+        const temaGuardado = localStorage.getItem('tema') || 'light';
+        document.body.setAttribute('data-theme', temaGuardado);
+        const btn = document.getElementById('toggle-dark-mode');
+        if (btn) {
+            btn.textContent = temaGuardado === 'dark' ? '☀ Modo Claro' : '🌙 Modo Oscuro';
+        }
     }
 
     // ========================================

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
       <header class="header">
         <h1><i class="fas fa-tasks"></i> Gestor de Tareas Personales</h1>
         <p>Organiza tus actividades de forma sencilla y eficiente</p>
+        <button id="toggle-dark-mode" class="btn btn-secondary">
+          🌙 Modo Oscuro
+        </button>
       </header>
 
       <!-- Panel de estadísticas -->

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@
     --light-color: #f8f9fa;
     --dark-color: #343a40;
     --border-color: #dee2e6;
+    --body-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     --shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     --border-radius: 8px;
     --transition: all 0.3s ease;
@@ -27,7 +28,7 @@
 
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: var(--body-bg);
     min-height: 100vh;
     color: var(--dark-color);
     line-height: 1.6;
@@ -574,4 +575,40 @@ body {
         width: 95%;
         margin: 10% auto;
     }
-} 
+}
+
+/* Dark mode */
+body[data-theme="dark"] {
+    --primary-color: #4a90e2;
+    --secondary-color: #adb5bd;
+    --success-color: #28a745;
+    --danger-color: #dc3545;
+    --warning-color: #ffc107;
+    --info-color: #17a2b8;
+    --light-color: #343a40;
+    --dark-color: #f8f9fa;
+    --border-color: #495057;
+    --body-bg: linear-gradient(135deg, #1f1f1f 0%, #3d3d3d 100%);
+}
+
+body[data-theme="dark"] .stat-card,
+body[data-theme="dark"] .form-container,
+body[data-theme="dark"] .controls,
+body[data-theme="dark"] .tareas-container,
+body[data-theme="dark"] .modal-content {
+    background: #2b2b2b;
+    color: var(--dark-color);
+}
+
+body[data-theme="dark"] .tarea-item {
+    background: #3a3a3a;
+    border-color: var(--border-color);
+}
+
+body[data-theme="dark"] .tarea-item.completada {
+    background: #2f2f2f;
+}
+
+body[data-theme="dark"] .estadistica-item {
+    background: #2f2f2f;
+}


### PR DESCRIPTION
## Summary
- add dark mode toggle button in UI
- add theme persistence and switch logic in app.js
- style dark mode and adjust CSS variables
- document dark mode in README-WEB

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6874ab396cac83209955d5345f6ebf15